### PR TITLE
fix(openai): forward CommandCode cache usage

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -75,10 +75,17 @@ export function mapUsageToOpenAI(usage: CommandCodeUsage | undefined): OpenAIUsa
   const promptTokens = usage?.inputTokens ?? 0;
   const completionTokens = usage?.outputTokens ?? 0;
   const totalTokens = usage?.totalTokens ?? promptTokens + completionTokens;
+  const cacheReadTokens = usage?.cachedInputTokens ?? usage?.inputTokenDetails?.["cacheReadTokens"];
   return {
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
     total_tokens: totalTokens,
+    prompt_tokens_details: {
+      cached_tokens:
+        typeof cacheReadTokens === "number" && Number.isFinite(cacheReadTokens)
+          ? cacheReadTokens
+          : 0,
+    },
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,9 @@ export interface OpenAIUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  prompt_tokens_details: {
+    cached_tokens: number;
+  };
 }
 
 export interface OpenAIChatCompletion {

--- a/tests/openai.test.ts
+++ b/tests/openai.test.ts
@@ -78,10 +78,18 @@ function parseSsePayloads(chunks: string[]): unknown[] {
 
 describe("CommandCode to OpenAI conversion", () => {
   it("maps usage fields", () => {
-    expect(mapUsageToOpenAI({ inputTokens: 3, outputTokens: 2, totalTokens: 5 })).toEqual({
+    expect(
+      mapUsageToOpenAI({
+        inputTokens: 3,
+        outputTokens: 2,
+        totalTokens: 5,
+        inputTokenDetails: { cacheReadTokens: 1 },
+      }),
+    ).toEqual({
       prompt_tokens: 3,
       completion_tokens: 2,
       total_tokens: 5,
+      prompt_tokens_details: { cached_tokens: 1 },
     });
   });
 


### PR DESCRIPTION
## Summary

Forward CommandCode cache-read usage to the OpenAI-compatible `prompt_tokens_details.cached_tokens` field.

## Scope

- Map `cachedInputTokens`, with the CommandCode 1.14.0 `inputTokenDetails.cacheReadTokens` wire shape as a fallback.
- Preserve `0` when upstream does not report a cache read.
- Cover the upstream cache-read payload shape with a regression test.

This PR intentionally does not change model catalogs, versions, configuration, or tray behavior.

## Verification

- `npm run verify`
- Live direct bridge request: `prompt_tokens_details.cached_tokens: 7552`
- Live OpenCodex proxy request and streaming usage chunk preserve the same cache detail.